### PR TITLE
Only track execute workers

### DIFF
--- a/view/queue.go
+++ b/view/queue.go
@@ -263,7 +263,7 @@ func (v *Queue) Update() {
   v.a.LastReapiLatency = time.Since(start)
   if err == nil {
     s.status = *st
-    s.workers = st.ActiveWorkers;
+    s.workers = st.ActiveExecuteWorkers;
   } else {
     panic(err)
     st, ok := status.FromError(err)


### PR DESCRIPTION
CAS-only workers just show up in the list as
```
stale, rpc error: code = Unimplemented desc = Method not found: build.buildfarm.v1test.WorkerProfile/GetWorkerProfile
```
