### PR TITLE
feat: support connecting to non-standard ports for grpcs

### DIFF
--- a/client/app.go
+++ b/client/app.go
@@ -63,7 +63,10 @@ func (a *App) Connect() {
 func connect(host string, ca string) *grpc.ClientConn {
   var opts []grpc.DialOption
   if strings.HasPrefix(host, "grpcs://") {
-    host = host[8:] + ":443"
+    host = host[8:]
+    if !strings.Contains(host, ":") {
+      host = host + ":443"
+    }
     creds, err := loadTLSCredentials(ca)
     if err != nil {
       panic(err)


### PR DESCRIPTION
If the URI already has a port, don't append ":443".

Example: `grpcs://rbe.company.com:8443`